### PR TITLE
Added a way to tell south to not apply any migrations

### DIFF
--- a/django_comments/south_migrations/0001_initial.py
+++ b/django_comments/south_migrations/0001_initial.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+from django.contrib.auth import get_user_model
+
+
+User = get_user_model()
+user_orm_label = '%s.%s' % (User._meta.app_label, User._meta.object_name)
+user_model_label = '%s.%s' % (User._meta.app_label, User._meta.module_name)
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Comment'
+        db.create_table('django_comments', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('content_type', self.gf('django.db.models.fields.related.ForeignKey')(related_name='content_type_set_for_comment', to=orm['contenttypes.ContentType'])),
+            ('object_pk', self.gf('django.db.models.fields.TextField')()),
+            ('site', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['sites.Site'])),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='comment_comments', null=True, to=orm[user_orm_label])),
+            ('user_name', self.gf('django.db.models.fields.CharField')(max_length=50, blank=True)),
+            ('user_email', self.gf('django.db.models.fields.EmailField')(max_length=75, blank=True)),
+            ('user_url', self.gf('django.db.models.fields.URLField')(max_length=200, blank=True)),
+            ('comment', self.gf('django.db.models.fields.TextField')(max_length=3000)),
+            ('submit_date', self.gf('django.db.models.fields.DateTimeField')(default=None)),
+            ('ip_address', self.gf('django.db.models.fields.GenericIPAddressField')(max_length=39, null=True, blank=True)),
+            ('is_public', self.gf('django.db.models.fields.BooleanField')(default=True)),
+            ('is_removed', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal(u'django_comments', ['Comment'])
+
+        # Adding model 'CommentFlag'
+        db.create_table('django_comment_flags', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(related_name='comment_flags', to=orm[user_orm_label])),
+            ('comment', self.gf('django.db.models.fields.related.ForeignKey')(related_name='flags', to=orm['django_comments.Comment'])),
+            ('flag', self.gf('django.db.models.fields.CharField')(max_length=30, db_index=True)),
+            ('flag_date', self.gf('django.db.models.fields.DateTimeField')(default=None)),
+        ))
+        db.send_create_signal(u'django_comments', ['CommentFlag'])
+
+        # Adding unique constraint on 'CommentFlag', fields ['user', 'comment', 'flag']
+        db.create_unique('django_comment_flags', ['user_id', 'comment_id', 'flag'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'CommentFlag', fields ['user', 'comment', 'flag']
+        db.delete_unique('django_comment_flags', ['user_id', 'comment_id', 'flag'])
+
+        # Deleting model 'Comment'
+        db.delete_table('django_comments')
+
+        # Deleting model 'CommentFlag'
+        db.delete_table('django_comment_flags')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        user_model_label: {
+            'Meta': {'object_name': User.__name__, 'db_table': "'{}'".format(User._meta.db_table)},
+            User._meta.pk.attname: ('django.db.models.fields.AutoField', [], {'primary_key': 'True', 'db_column': "'{}'".format(User._meta.pk.column)}),
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'django_comments.comment': {
+            'Meta': {'ordering': "('submit_date',)", 'object_name': 'Comment', 'db_table': "'django_comments'"},
+            'comment': ('django.db.models.fields.TextField', [], {'max_length': '3000'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'content_type_set_for_comment'", 'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True', 'blank': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_removed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'object_pk': ('django.db.models.fields.TextField', [], {}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'submit_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'comment_comments'", 'null': 'True', 'to': u"orm['{}']".format(user_orm_label)}),
+            'user_email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'user_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'user_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        u'django_comments.commentflag': {
+            'Meta': {'unique_together': "[('user', 'comment', 'flag')]", 'object_name': 'CommentFlag', 'db_table': "'django_comment_flags'"},
+            'comment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'flags'", 'to': u"orm['django_comments.Comment']"}),
+            'flag': ('django.db.models.fields.CharField', [], {'max_length': '30', 'db_index': 'True'}),
+            'flag_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comment_flags'", 'to': u"orm['{}']".format(user_orm_label)})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['django_comments']


### PR DESCRIPTION
This allows the django1.6 south users to co-exist with 1.7 migrations. This pull request can supplant #18 