### PR TITLE
Adapting code to avoid Django 1.8 deprectation warnings

### DIFF
--- a/django_comments/managers.py
+++ b/django_comments/managers.py
@@ -8,7 +8,7 @@ class CommentManager(models.Manager):
         """
         QuerySet for all comments currently in the moderation queue.
         """
-        return self.get_query_set().filter(is_public=False, is_removed=False)
+        return self.get_queryset().filter(is_public=False, is_removed=False)
 
     def for_model(self, model):
         """
@@ -16,7 +16,7 @@ class CommentManager(models.Manager):
         a class).
         """
         ct = ContentType.objects.get_for_model(model)
-        qs = self.get_query_set().filter(content_type=ct)
+        qs = self.get_queryset().filter(content_type=ct)
         if isinstance(model, models.Model):
             qs = qs.filter(object_pk=force_text(model._get_pk_val()))
         return qs

--- a/django_comments/moderation.py
+++ b/django_comments/moderation.py
@@ -303,7 +303,7 @@ class Moderator(object):
             model_or_iterable = [model_or_iterable]
         for model in model_or_iterable:
             if model in self._registry:
-                raise AlreadyModerated("The model '%s' is already being moderated" % model._meta.module_name)
+                raise AlreadyModerated("The model '%s' is already being moderated" % model._meta.model_name)
             self._registry[model] = moderation_class(model)
 
     def unregister(self, model_or_iterable):
@@ -319,7 +319,7 @@ class Moderator(object):
             model_or_iterable = [model_or_iterable]
         for model in model_or_iterable:
             if model not in self._registry:
-                raise NotModerated("The model '%s' is not currently being moderated" % model._meta.module_name)
+                raise NotModerated("The model '%s' is not currently being moderated" % model._meta.model_name)
             del self._registry[model]
 
     def pre_save_moderation(self, sender, comment, request, **kwargs):

--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -86,10 +86,10 @@ def post_comment(request, next=None, using=None):
             # These first two exist for purely historical reasons.
             # Django v1.0 and v1.1 allowed the underscore format for
             # preview templates, so we have to preserve that format.
-            "comments/%s_%s_preview.html" % (model._meta.app_label, model._meta.module_name),
+            "comments/%s_%s_preview.html" % (model._meta.app_label, model._meta.model_name),
             "comments/%s_preview.html" % model._meta.app_label,
             # Now the usual directory based template hierarchy.
-            "comments/%s/%s/preview.html" % (model._meta.app_label, model._meta.module_name),
+            "comments/%s/%s/preview.html" % (model._meta.app_label, model._meta.model_name),
             "comments/%s/preview.html" % model._meta.app_label,
             "comments/preview.html",
         ]


### PR DESCRIPTION
Hi!

I have updated the code to avoid warnings to be raised (RemovedInDjango18Warning when using django.db.models.Manager.get_query_set and model._meta.model_name).

I ran the tests which passed:
> (django-contrib-comments)MacBook-Air-de-Quentin:django-contrib-comments quentin$ python tests/runtests.py 
> Creating test database for alias 'default'...
> ..............s.............................................................................................
> ----------------------------------------------------------------------
> Ran 108 tests in 33.656s

> OK (skipped=1)
> Destroying test database for alias 'default'...

This is my first commit so do not hesitate to ask for changes or have a chat with me.

If it is ok for you then, could you please pull this update?

Cheers,
Quentin