### PR TITLE
Added app_label to models

### DIFF
--- a/django_comments/models.py
+++ b/django_comments/models.py
@@ -79,6 +79,7 @@ class Comment(BaseCommentAbstractModel):
     objects = CommentManager()
 
     class Meta:
+        app_label = 'django_comments'
         db_table = "django_comments"
         ordering = ('submit_date',)
         permissions = [("can_moderate", "Can moderate comments")]
@@ -195,6 +196,7 @@ class CommentFlag(models.Model):
     MODERATOR_APPROVAL = "moderator approval"
 
     class Meta:
+        app_label = 'django_comments'
         db_table = 'django_comment_flags'
         unique_together = [('user', 'comment', 'flag')]
         verbose_name = _('comment flag')


### PR DESCRIPTION
According models to Django 1.9.

django_comments raised this warning for Comment and CommentFlag:
RemovedInDjango19Warning: Model class django_comments.models.Comment doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.

I simply add "app_label = 'django_comments'" to models' Meta.