### PR TITLE
Added `zip_safe=False` arg to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author_email='jacob@jacobian.org',
     license='BSD',
     platforms='any',
+    zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
It looks like Django 1.7's migrations don't support inspecting the migrations directory when a library is installed as an egg, as described here: https://groups.google.com/forum/#!msg/mezzanine-users/_QWfFVB3RVc/E9c9oKXN0F0J

This change simply adds the `zip_safe=False` arg to setup.py - with that included and a new release pushed to PyPI, people will be able to pip install this and have the migrations work correctly.

Thanks a lot!