### PR TITLE
Prevent RemovedInDjango19Warning on Django1.8

### DIFF
--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import django
 from django import http
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -14,6 +15,12 @@ from django.views.decorators.http import require_POST
 import django_comments
 from django_comments import signals
 from django_comments.views.utils import next_redirect, confirmation_view
+
+
+if django.VERSION < (1, 8):
+    from django.db.models import get_model
+else:
+    from django.db.models.loading import get_model
 
 
 class CommentPostBadRequest(http.HttpResponseBadRequest):
@@ -52,7 +59,7 @@ def post_comment(request, next=None, using=None):
     if ctype is None or object_pk is None:
         return CommentPostBadRequest("Missing content_type or object_pk field.")
     try:
-        model = models.get_model(*ctype.split(".", 1))
+        model = get_model(*ctype.split(".", 1))
         target = model._default_manager.using(using).get(pk=object_pk)
     except TypeError:
         return CommentPostBadRequest(

--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -18,9 +18,9 @@ from django_comments.views.utils import next_redirect, confirmation_view
 
 
 if django.VERSION < (1, 8):
-    from django.db.models import get_model
+    from django.db import models as apps
 else:
-    from django.db.models.loading import get_model
+    from django.apps import apps
 
 
 class CommentPostBadRequest(http.HttpResponseBadRequest):
@@ -59,7 +59,7 @@ def post_comment(request, next=None, using=None):
     if ctype is None or object_pk is None:
         return CommentPostBadRequest("Missing content_type or object_pk field.")
     try:
-        model = get_model(*ctype.split(".", 1))
+        model = apps.get_model(*ctype.split(".", 1))
         target = model._default_manager.using(using).get(pk=object_pk)
     except TypeError:
         return CommentPostBadRequest(

--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -17,10 +17,10 @@ from django_comments import signals
 from django_comments.views.utils import next_redirect, confirmation_view
 
 
-if django.VERSION < (1, 8):
-    from django.db import models as apps
-else:
+try:
     from django.apps import apps
+except ImportError:
+    from django.db import models as apps
 
 
 class CommentPostBadRequest(http.HttpResponseBadRequest):

--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import django
 from django import http
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError


### PR DESCRIPTION
On Django.1.8, `django.db.models.get_model` moved to `django.db.models.loading.get_model`. So I added version checking before loading `get_model`.