### PR TITLE
Prevented  get_current_site deprecation warning

### DIFF
--- a/django_comments/compat.py
+++ b/django_comments/compat.py
@@ -1,0 +1,4 @@
+try:
+    from django.contrib.sites.shortcuts import get_current_site
+except ImportError:
+    from django.contrib.sites.models import get_current_site

--- a/django_comments/feeds.py
+++ b/django_comments/feeds.py
@@ -1,8 +1,9 @@
 from django.contrib.syndication.views import Feed
-from django.contrib.sites.models import get_current_site
 from django.utils.translation import ugettext as _
 
 import django_comments
+
+from .compat import get_current_site
 
 
 class LatestCommentFeed(Feed):

--- a/django_comments/moderation.py
+++ b/django_comments/moderation.py
@@ -60,11 +60,12 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.db.models.base import ModelBase
 from django.template import Context, loader
-from django.contrib.sites.models import get_current_site
 from django.utils import timezone
 
 import django_comments
 from django_comments import signals
+
+from .compat import get_current_site
 
 
 class AlreadyModerated(Exception):

--- a/tests/custom_comments/__init__.py
+++ b/tests/custom_comments/__init__.py
@@ -1,9 +1,9 @@
 from django.core import urlresolvers
-from .models import CustomComment
 from .forms import CustomCommentForm
 
 
 def get_model():
+    from .models import CustomComment
     return CustomComment
 
 

--- a/tests/testapp/tests/__init__.py
+++ b/tests/testapp/tests/__init__.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 from django_comments.forms import CommentForm
 from django_comments.models import Comment
 
-from ..models import Article, Author
+from testapp.models import Article, Author
 
 # Shortcut
 CT = ContentType.objects.get_for_model

--- a/tests/testapp/tests/test_comment_form.py
+++ b/tests/testapp/tests/test_comment_form.py
@@ -8,7 +8,7 @@ from django_comments.forms import CommentForm
 from django_comments.models import Comment
 
 from . import CommentTestCase
-from ..models import Article
+from testapp.models import Article
 
 
 class CommentFormTests(CommentTestCase):

--- a/tests/testapp/tests/test_comment_utils_moderators.py
+++ b/tests/testapp/tests/test_comment_utils_moderators.py
@@ -8,7 +8,7 @@ from django_comments.moderation import (moderator, CommentModerator,
     AlreadyModerated)
 
 from . import CommentTestCase
-from ..models import Entry
+from testapp.models import Entry
 
 
 class EntryModerator1(CommentModerator):

--- a/tests/testapp/tests/test_comment_views.py
+++ b/tests/testapp/tests/test_comment_views.py
@@ -9,7 +9,7 @@ from django_comments import signals
 from django_comments.models import Comment
 
 from . import CommentTestCase
-from ..models import Article, Book
+from testapp.models import Article, Book
 
 
 post_redirect_re = re.compile(r'^http://testserver/posted/\?c=(?P<pk>\d+$)')

--- a/tests/testapp/tests/test_feeds.py
+++ b/tests/testapp/tests/test_feeds.py
@@ -9,7 +9,7 @@ from django.contrib.sites.models import Site
 from django_comments.models import Comment
 
 from . import CommentTestCase
-from ..models import Article
+from testapp.models import Article
 
 
 class CommentFeedTests(CommentTestCase):

--- a/tests/testapp/tests/test_models.py
+++ b/tests/testapp/tests/test_models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django_comments.models import Comment
 
 from . import CommentTestCase
-from ..models import Author, Article
+from testapp.models import Author, Article
 
 
 class CommentModelTests(CommentTestCase):

--- a/tests/testapp/tests/test_templatetags.py
+++ b/tests/testapp/tests/test_templatetags.py
@@ -7,7 +7,7 @@ from django.template.base import libraries
 from django_comments.forms import CommentForm
 from django_comments.models import Comment
 
-from ..models import Article, Author
+from testapp.models import Article, Author
 from . import CommentTestCase
 
 register = Library()

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist = py26-django16, py27-django16, py32-django16, py33-django16,
 
 [testenv]
 commands = {envpython} setup.py test
+setenv=
+  PYTHONWARNINGS=default
 
 [testenv:py26-django16]
 basepython = python2.6


### PR DESCRIPTION
there is still a bunch of warnings when using `Django>=1.8`, but those are related to the tests and the `custom_comments` app.