### PR TITLE
Removed unneeded try/except blocks

### DIFF
--- a/django_comments/__init__.py
+++ b/django_comments/__init__.py
@@ -1,11 +1,8 @@
+from importlib import import_module
+
 from django.conf import settings
 from django.core import urlresolvers
 from django.core.exceptions import ImproperlyConfigured
-
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
 
 
 DEFAULT_COMMENTS_APP = 'django_comments'

--- a/django_comments/compat.py
+++ b/django_comments/compat.py
@@ -1,4 +1,3 @@
-try:
-    from django.contrib.sites.shortcuts import get_current_site
-except ImportError:
-    from django.contrib.sites.models import get_current_site
+"""
+Module to store compatiblity imports to prevent Django deprecation warnings.
+"""

--- a/django_comments/feeds.py
+++ b/django_comments/feeds.py
@@ -1,9 +1,8 @@
+from django.contrib.sites.shortcuts import get_current_site
 from django.contrib.syndication.views import Feed
 from django.utils.translation import ugettext as _
 
 import django_comments
-
-from .compat import get_current_site
 
 
 class LatestCommentFeed(Feed):

--- a/django_comments/forms.py
+++ b/django_comments/forms.py
@@ -1,14 +1,9 @@
 import time
 
 from django import forms
-
-try:
-    from django.forms.utils import ErrorDict
-except ImportError:
-    from django.forms.util import ErrorDict
-
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.forms.utils import ErrorDict
 from django.utils.crypto import salted_hmac, constant_time_compare
 from django.utils.encoding import force_text
 from django.utils.text import get_text_list

--- a/django_comments/models.py
+++ b/django_comments/models.py
@@ -1,10 +1,5 @@
 from django.conf import settings
-
-try:
-    from django.contrib.contenttypes.fields import GenericForeignKey
-except ImportError:
-    from django.contrib.contenttypes.generic import GenericForeignKey
-
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core import urlresolvers

--- a/django_comments/moderation.py
+++ b/django_comments/moderation.py
@@ -58,6 +58,7 @@ import datetime
 
 from django import VERSION
 from django.conf import settings
+from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.db.models.base import ModelBase
 from django.template import Context, loader
@@ -65,8 +66,6 @@ from django.utils import timezone
 
 import django_comments
 from django_comments import signals
-
-from .compat import get_current_site
 
 
 class AlreadyModerated(Exception):

--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django import http
+from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
@@ -9,11 +10,6 @@ from django.template.loader import render_to_string
 from django.utils.html import escape
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
-
-try:
-    from django.apps import apps
-except ImportError:
-    from django.db import models as apps
 
 import django_comments
 from django_comments import signals

--- a/tests/testapp/tests/test_app_api.py
+++ b/tests/testapp/tests/test_app_api.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
+import unittest
 
 import django
 from django.conf import settings


### PR DESCRIPTION
Now that Django 1.6 has been dropped, those conditional imports can be
dropped also.