### PR TITLE
Added app_label to models to prevent RemovedInDjango19Warning upon im…

### DIFF
--- a/django_comments/models.py
+++ b/django_comments/models.py
@@ -169,6 +169,7 @@ class CommentAbstractModel(BaseCommentAbstractModel):
 
 class Comment(CommentAbstractModel):
     class Meta(CommentAbstractModel.Meta):
+        app_label = "django_comments"
         db_table = "django_comments"
 
 
@@ -197,6 +198,7 @@ class CommentFlag(models.Model):
     MODERATOR_APPROVAL = "moderator approval"
 
     class Meta:
+        app_label = 'django_comments'
         db_table = 'django_comment_flags'
         unique_together = [('user', 'comment', 'flag')]
         verbose_name = _('comment flag')


### PR DESCRIPTION
In some some scenarios for importing the app using Django 1.8, it is possible to receive:

RemovedInDjango19Warning: Model class django_comments.models.Comment doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.

 This request adds the labels in order to suppress the warning in Django 1.8 and allow app's usage in Django 1.9.