### PR TITLE
Use queryset as context value of CommentListNode

### DIFF
--- a/django_comments/templatetags/comments.py
+++ b/django_comments/templatetags/comments.py
@@ -114,7 +114,7 @@ class CommentListNode(BaseCommentNode):
     """Insert a list of comments into the context."""
 
     def get_context_value_from_queryset(self, context, qs):
-        return list(qs)
+        return qs
 
 
 class CommentCountNode(BaseCommentNode):


### PR DESCRIPTION
Before it was a list, but the behaviour should not change.
Fixes #26