### PR TITLE
Added settings for control HTTP code of errored form

### DIFF
--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -15,6 +15,9 @@ import django_comments
 from django_comments import signals
 from django_comments.views.utils import next_redirect, confirmation_view
 
+UNVALID_FORM_HTTP_CODE = getattr(settings, 'COMMENT_UNVALID_FORM_HTTP_CODE',
+                                 200)
+
 
 class CommentPostBadRequest(http.HttpResponseBadRequest):
     """
@@ -97,7 +100,7 @@ def post_comment(request, next=None, using=None):
                 "comment": form.data.get("comment", ""),
                 "form": form,
                 "next": data.get("next", next),
-            },
+            }, status=UNVALID_FORM_HTTP_CODE
         )
 
     # Otherwise create the comment

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -35,7 +35,13 @@ must also be listed in :setting:`INSTALLED_APPS`.
 .. setting:: COMMENTS_TIMEOUT
 
 COMMENT_TIMEOUT
-------------------
+---------------
 
 The maximum comment form timeout in seconds. The default value is
 ``2 * 60 * 60`` (2 hours).
+
+COMMENT_UNVALID_FORM_HTTP_CODE
+------------------------------
+
+The HTTP response code sent when unvalid form is submitted. The default value
+is ``200`` (OK).


### PR DESCRIPTION
It could be useful ton control easily the HTTP code sent when the comment form is badly filled.

The app actually response a 200 (OK) which can sound bad for many devs. Some would like 400 or 422.