### PR TITLE
Update forms.py to pass W3C validation

### DIFF
--- a/django_comments/forms.py
+++ b/django_comments/forms.py
@@ -23,7 +23,7 @@ class CommentSecurityForm(forms.Form):
     content_type = forms.CharField(widget=forms.HiddenInput)
     object_pk = forms.CharField(widget=forms.HiddenInput)
     timestamp = forms.IntegerField(widget=forms.HiddenInput)
-    security_hash = forms.CharField(min_length=40, max_length=40, widget=forms.HiddenInput)
+    security_hash = forms.CharField(widget=forms.HiddenInput)
 
     def __init__(self, target_object, data=None, initial=None, **kwargs):
         self.target_object = target_object


### PR DESCRIPTION
W3 validator complains about maxlength attributes on hidden fields, so I've removed maxlength and minlength from security_hash object.