### PR TITLE
Stopped setup.py from packaging test submodules

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ History
 Pending
 -------
 
+* Fixed a packaging error which caused sub-packages of the tests to be
+  distributed.
+
 1.7.3 (2016-09-13)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     test_suite='tests.runtests.main',
     install_requires=['Django>=1.7']


### PR DESCRIPTION
Found them installed in my `site-packages` :scream:

Checked change in shell:

```
In [2]: find_packages(exclude=['tests'])
Out[2]:
['django_comments',
 'django_comments.migrations',
 'django_comments.templatetags',
 'django_comments.views',
 'tests.custom_comments',
 'tests.testapp',
 'tests.testapp.templatetags',
 'tests.testapp.tests']

In [3]: find_packages(exclude=['tests', 'tests.*'])
Out[3]:
['django_comments',
 'django_comments.migrations',
 'django_comments.templatetags',
 'django_comments.views']
```