### PR TITLE
Use get_current_site to look up the site instead of settings.SITE_ID

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending
 
 * Fixed a packaging error which caused sub-packages of the tests to be
   distributed.
+* Use ``get_current_site`` to look up the site instead of ``settings.SITE_ID``.
 
 1.7.3 (2016-09-13)
 ------------------

--- a/django_comments/forms.py
+++ b/django_comments/forms.py
@@ -105,7 +105,7 @@ class CommentDetailsForm(CommentSecurityForm):
     comment = forms.CharField(label=_('Comment'), widget=forms.Textarea,
                               max_length=COMMENT_MAX_LENGTH)
 
-    def get_comment_object(self):
+    def get_comment_object(self, site_id=None):
         """
         Return a new (unsaved) comment object based on the information in this
         form. Assumes that the form is already validated and will throw a
@@ -118,7 +118,7 @@ class CommentDetailsForm(CommentSecurityForm):
             raise ValueError("get_comment_object may only be called on valid forms")
 
         CommentModel = self.get_comment_model()
-        new = CommentModel(**self.get_comment_create_data())
+        new = CommentModel(**self.get_comment_create_data(site_id=site_id))
         new = self.check_for_duplicate_comment(new)
 
         return new
@@ -131,7 +131,7 @@ class CommentDetailsForm(CommentSecurityForm):
         """
         return get_model()
 
-    def get_comment_create_data(self):
+    def get_comment_create_data(self, site_id=None):
         """
         Returns the dict of data to be used to create a comment. Subclasses in
         custom comment apps that override get_comment_model can override this
@@ -145,7 +145,7 @@ class CommentDetailsForm(CommentSecurityForm):
             user_url=self.cleaned_data["url"],
             comment=self.cleaned_data["comment"],
             submit_date=timezone.now(),
-            site_id=settings.SITE_ID,
+            site_id=site_id or settings.SITE_ID,
             is_public=True,
             is_removed=False,
         )

--- a/django_comments/forms.py
+++ b/django_comments/forms.py
@@ -145,7 +145,7 @@ class CommentDetailsForm(CommentSecurityForm):
             user_url=self.cleaned_data["url"],
             comment=self.cleaned_data["comment"],
             submit_date=timezone.now(),
-            site_id=site_id or settings.SITE_ID,
+            site_id=site_id or getattr(settings, "SITE_ID", None),
             is_public=True,
             is_removed=False,
         )

--- a/django_comments/templatetags/comments.py
+++ b/django_comments/templatetags/comments.py
@@ -77,9 +77,12 @@ class BaseCommentNode(template.Node):
         if not object_pk:
             return self.comment_model.objects.none()
 
-        site_id = settings.SITE_ID
-        if 'request' in context:
+        # Explicit SITE_ID takes precedence over request. This is also how
+        # get_current_site operates.
+        site_id = getattr(settings, "SITE_ID", None)
+        if not site_id and ('request' in context):
             site_id = get_current_site(context['request']).pk
+
         qs = self.comment_model.objects.filter(
             content_type=ctype,
             object_pk=smart_text(object_pk),

--- a/django_comments/templatetags/comments.py
+++ b/django_comments/templatetags/comments.py
@@ -2,6 +2,7 @@ from django import template
 from django.template.loader import render_to_string
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.shortcuts import get_current_site
 from django.utils.encoding import smart_text
 
 import django_comments
@@ -76,10 +77,13 @@ class BaseCommentNode(template.Node):
         if not object_pk:
             return self.comment_model.objects.none()
 
+        site_id = settings.SITE_ID
+        if 'request' in context:
+            site_id = get_current_site(context['request']).pk
         qs = self.comment_model.objects.filter(
             content_type=ctype,
             object_pk=smart_text(object_pk),
-            site__pk=settings.SITE_ID,
+            site__pk=site_id,
         )
 
         # The is_public and is_removed fields are implementation details of the

--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django import http
 from django.apps import apps
 from django.conf import settings
+from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.shortcuts import render
 from django.template.loader import render_to_string
@@ -100,7 +101,7 @@ def post_comment(request, next=None, using=None):
         )
 
     # Otherwise create the comment
-    comment = form.get_comment_object()
+    comment = form.get_comment_object(site_id=get_current_site(request).id)
     comment.ip_address = request.META.get("REMOTE_ADDR", None)
     if request.user.is_authenticated():
         comment.user = request.user

--- a/django_comments/views/moderation.py
+++ b/django_comments/views/moderation.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import csrf_protect
 
@@ -21,7 +22,9 @@ def flag(request, comment_id, next=None):
         comment
             the flagged `comments.comment` object
     """
-    comment = get_object_or_404(django_comments.get_model(), pk=comment_id, site__pk=settings.SITE_ID)
+    comment = get_object_or_404(django_comments.get_model(),
+                                pk=comment_id,
+                                site__pk=get_current_site(request).pk)
 
     # Flag on POST
     if request.method == 'POST':
@@ -46,7 +49,9 @@ def delete(request, comment_id, next=None):
         comment
             the flagged `comments.comment` object
     """
-    comment = get_object_or_404(django_comments.get_model(), pk=comment_id, site__pk=settings.SITE_ID)
+    comment = get_object_or_404(django_comments.get_model(),
+                                pk=comment_id,
+                                site__pk=get_current_site(request).pk)
 
     # Delete on POST
     if request.method == 'POST':
@@ -72,7 +77,9 @@ def approve(request, comment_id, next=None):
         comment
             the `comments.comment` object for approval
     """
-    comment = get_object_or_404(django_comments.get_model(), pk=comment_id, site__pk=settings.SITE_ID)
+    comment = get_object_or_404(django_comments.get_model(),
+                                pk=comment_id,
+                                site__pk=get_current_site(request).pk)
 
     # Delete on POST
     if request.method == 'POST':

--- a/tests/testapp/tests/test_templatetags.py
+++ b/tests/testapp/tests/test_templatetags.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from django import get_version
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
@@ -105,6 +106,11 @@ class CommentTemplateTagTests(CommentTestCase):
         self.verifyGetCommentList("{% get_comment_list for a as cl %}")
 
     def testGetCommentListUsingRequest(self, tag=None):
+        # Retrieving a site from the request is not available in Django 1.7,
+        # our minimum supported version.
+        if get_version().startswith("1.7"):
+            return
+
         # A request lookup should return site_2
         with override_settings(SITE_ID=self.site_2.id):
             c1, c2, c3, c4 = self.createSomeComments()

--- a/tests/testapp/tests/test_templatetags.py
+++ b/tests/testapp/tests/test_templatetags.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
 from django.template import Template, Context
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
 
 from django_comments.forms import CommentForm
 from django_comments.models import Comment
@@ -11,6 +15,11 @@ from . import CommentTestCase
 
 
 class CommentTemplateTagTests(CommentTestCase):
+
+    def setUp(self):
+        super(CommentTemplateTagTests, self).setUp()
+        self.site_2 = Site.objects.create(id=settings.SITE_ID + 1,
+            domain="testserver", name="testserver")
 
     def render(self, t, **c):
         ctx = Context(c)
@@ -94,6 +103,19 @@ class CommentTemplateTagTests(CommentTestCase):
     def testGetCommentListFromObject(self):
         self.createSomeComments()
         self.verifyGetCommentList("{% get_comment_list for a as cl %}")
+
+    def testGetCommentListUsingRequest(self, tag=None):
+        # A request lookup should return site_2
+        with override_settings(SITE_ID=self.site_2.id):
+            c1, c2, c3, c4 = self.createSomeComments()
+
+        # Effectively unset SITE_ID which forces a site lookup from the
+        # request. Create a new comment for the second site.
+        with override_settings(SITE_ID=None):
+            t = "{% load comments %}" + (tag or "{% get_comment_list for testapp.author a.id as cl %}")
+            request = RequestFactory().get("/")
+            ctx, out = self.render(t, a=Author.objects.get(pk=1), request=request)
+            self.assertEqual(list(ctx["cl"]), [c2])
 
     def testWhitespaceInGetCommentListTag(self):
         self.createSomeComments()

--- a/tests/testapp/tests/test_templatetags.py
+++ b/tests/testapp/tests/test_templatetags.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import unittest
+
 from django import get_version
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -105,12 +107,10 @@ class CommentTemplateTagTests(CommentTestCase):
         self.createSomeComments()
         self.verifyGetCommentList("{% get_comment_list for a as cl %}")
 
+    @unittest.skipIf(get_version().startswith("1.7"),
+                    "Retrieving a site from the request is not available in \
+                    Django 1.7")
     def testGetCommentListUsingRequest(self, tag=None):
-        # Retrieving a site from the request is not available in Django 1.7,
-        # our minimum supported version.
-        if get_version().startswith("1.7"):
-            return
-
         # A request lookup should return site_2
         with override_settings(SITE_ID=self.site_2.id):
             c1, c2, c3, c4 = self.createSomeComments()

--- a/tests/testapp/tests/test_templatetags.py
+++ b/tests/testapp/tests/test_templatetags.py
@@ -108,8 +108,7 @@ class CommentTemplateTagTests(CommentTestCase):
         self.verifyGetCommentList("{% get_comment_list for a as cl %}")
 
     @unittest.skipIf(get_version().startswith("1.7"),
-                    "Retrieving a site from the request is not available in \
-                    Django 1.7")
+                    "Retrieving a site from the request is not available in Django 1.7")
     def testGetCommentListUsingRequest(self, tag=None):
         # A request lookup should return site_2
         with override_settings(SITE_ID=self.site_2.id):


### PR DESCRIPTION
Use `get_current_site` to look up the site instead of `settings.SITE_ID`. This fixes the case where the site is looked up from the request, which is a typical use case for multitenancy systems that don't spin up a Django process per site.