### PR TITLE
Added auth context processor to test settings.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -37,6 +37,7 @@ settings.configure(
             'APP_DIRS': True,
             'OPTIONS': {
                 'context_processors': [
+                    'django.contrib.auth.context_processors.auth',
                     'django.contrib.messages.context_processors.messages',
                 ]
             },


### PR DESCRIPTION
In Django 1.11, system checks run as part of the tests and failed:
'django.contrib.auth.context_processors.auth' must be in TEMPLATES
in order to use the admin application.