### PR TITLE
Allowed Travis failures for Django master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ env:
 - TOXENV=py27-django110
 - TOXENV=py34-django110
 - TOXENV=py35-django110
-- TOXENV=py27-django-master
 - TOXENV=py34-django-master
 - TOXENV=py35-django-master
+matrix:
+  allow_failures:
+    - env: TOXENV=py34-django-master
+    - env: TOXENV=py35-django-master
 install:
 - pip install tox
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,34,35}-django1{8,9,10}
-    py{27,34,35}-master
+    py{34,35}-master
 
 [testenv]
 basepython =


### PR DESCRIPTION
Support for Django 2.0 will be added upon its release (while dropping support for Django < 1.11).