### PR TITLE
Fix missing NL translation for "Name"

### DIFF
--- a/django_comments/locale/nl/LC_MESSAGES/django.po
+++ b/django_comments/locale/nl/LC_MESSAGES/django.po
@@ -77,7 +77,7 @@ msgstr "Laatste opmerkingen op %(site_name)s"
 #: forms.py:105
 msgctxt "Person name"
 msgid "Name"
-msgstr ""
+msgstr "Naam"
 
 #: forms.py:97
 msgid "Email address"


### PR DESCRIPTION
The "Name" field is not translated, giving a bad appearance on Dutch websites.