### PR TITLE
Make sites optional

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 =======
 
+Pending
+-------
+
+* 'sites' framework continues to be supported but is no longer required.
+
 1.8.0 (2017-02-03)
 ------------------
 

--- a/django_comments/abstracts.py
+++ b/django_comments/abstracts.py
@@ -33,7 +33,7 @@ class BaseCommentAbstractModel(models.Model):
     content_object = GenericForeignKey(ct_field="content_type", fk_field="object_pk")
 
     # Metadata about the comment
-    site = models.ForeignKey(Site, on_delete=models.CASCADE)
+    site = models.ForeignKey(Site, on_delete=models.CASCADE, null=True)
 
     class Meta:
         abstract = True
@@ -168,7 +168,10 @@ class CommentAbstractModel(BaseCommentAbstractModel):
             'user': self.user or self.name,
             'date': self.submit_date,
             'comment': self.comment,
-            'domain': self.site.domain,
+            'domain': self.site.domain if self.site else '',
             'url': self.get_absolute_url()
         }
-        return _('Posted by %(user)s at %(date)s\n\n%(comment)s\n\nhttp://%(domain)s%(url)s') % d
+        if self.site:
+            return _('Posted by %(user)s at %(date)s\n\n%(comment)s\n\nhttp://%(domain)s%(url)s') % d
+        else:
+            return _('Posted by %(user)s at %(date)s\n\n%(comment)s') % d

--- a/django_comments/feeds.py
+++ b/django_comments/feeds.py
@@ -23,7 +23,7 @@ class LatestCommentFeed(Feed):
 
     def items(self):
         qs = django_comments.get_model().objects.filter(
-            site__pk=self.site.pk,
+            site__pk=getattr(self.site, 'pk', None),
             is_public=True,
             is_removed=False,
         )

--- a/django_comments/migrations/0001_initial.py
+++ b/django_comments/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.conf import settings
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('sites', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('contenttypes', '0001_initial'),
     ]

--- a/django_comments/migrations/0004_allow_null_site.py
+++ b/django_comments/migrations/0004_allow_null_site.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_comments', '0003_add_submit_date_index'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='comment',
+            name='site',
+            field=models.ForeignKey(to='sites.Site', on_delete=models.CASCADE, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/django_comments/templatetags/comments.py
+++ b/django_comments/templatetags/comments.py
@@ -81,7 +81,7 @@ class BaseCommentNode(template.Node):
         # get_current_site operates.
         site_id = getattr(settings, "SITE_ID", None)
         if not site_id and ('request' in context):
-            site_id = get_current_site(context['request']).pk
+            site_id = getattr(get_current_site(context['request']), 'pk', None)
 
         qs = self.comment_model.objects.filter(
             content_type=ctype,

--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -105,7 +105,7 @@ def post_comment(request, next=None, using=None):
         )
 
     # Otherwise create the comment
-    comment = form.get_comment_object(site_id=get_current_site(request).id)
+    comment = form.get_comment_object(site_id=getattr(get_current_site(request), 'id', None))
     comment.ip_address = request.META.get("REMOTE_ADDR", None)
     if user_is_authenticated:
         comment.user = request.user

--- a/django_comments/views/moderation.py
+++ b/django_comments/views/moderation.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from django.conf import settings
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import get_object_or_404, render
@@ -24,7 +23,7 @@ def flag(request, comment_id, next=None):
     """
     comment = get_object_or_404(django_comments.get_model(),
                                 pk=comment_id,
-                                site__pk=get_current_site(request).pk)
+                                site__pk=getattr(get_current_site(request), 'pk', None))
 
     # Flag on POST
     if request.method == 'POST':
@@ -51,7 +50,7 @@ def delete(request, comment_id, next=None):
     """
     comment = get_object_or_404(django_comments.get_model(),
                                 pk=comment_id,
-                                site__pk=get_current_site(request).pk)
+                                site__pk=getattr(get_current_site(request), 'pk', None))
 
     # Delete on POST
     if request.method == 'POST':
@@ -79,7 +78,7 @@ def approve(request, comment_id, next=None):
     """
     comment = get_object_or_404(django_comments.get_model(),
                                 pk=comment_id,
-                                site__pk=get_current_site(request).pk)
+                                site__pk=getattr(get_current_site(request), 'pk', None))
 
     # Delete on POST
     if request.method == 'POST':

--- a/docs/models.txt
+++ b/docs/models.txt
@@ -35,7 +35,7 @@ The comment models
 
         A :class:`~django.db.models.ForeignKey` to the
         :class:`~django.contrib.sites.models.Site` on which the comment was
-        posted.
+        posted.  Will be `None` if not using the 'sites' framework.
 
     .. attribute:: user
 

--- a/docs/quickstart.txt
+++ b/docs/quickstart.txt
@@ -6,10 +6,6 @@ To get started using the ``comments`` app, follow these steps:
 
 #. Install the comments app by running ``pip install django-contrib-comments``.
 
-#. :ref:`Enable the "sites" framework <enabling-the-sites-framework>` by adding
-   ``'django.contrib.sites'`` to :setting:`INSTALLED_APPS` and defining
-   :setting:`SITE_ID`.
-
 #. Install the comments framework by adding ``'django_comments'`` to
    :setting:`INSTALLED_APPS`.
 


### PR DESCRIPTION
As mentioned in #15, this change is to continue supporting the "sites" framework, but also make it work without it so it's now optional.

NOTE:
 - there's one translatable string added (I wanted to retain the existing string so existing translations would continue working.  The new string is the same but with the URL and linefeeds removed.)
 - tests haven't been changed to test for running with no `SITE_ID` or sites framework installed.  Should all the tests be run twice, once with sites and once without?