### PR TITLE
Used python_2_unicode_compatible() from six.

### DIFF
--- a/django_comments/abstracts.py
+++ b/django_comments/abstracts.py
@@ -7,8 +7,8 @@ from django.contrib.sites.models import Site
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+from six import python_2_unicode_compatible
 
 from .managers import CommentManager
 

--- a/django_comments/models.py
+++ b/django_comments/models.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+from six import python_2_unicode_compatible
 
 from .abstracts import (
     COMMENT_MAX_LENGTH, BaseCommentAbstractModel, CommentAbstractModel,

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     test_suite='tests.runtests.main',
-    install_requires=['Django>=1.11']
+    install_requires=['Django>=1.11', 'six']
 )

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -6,7 +6,7 @@ more information.
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
`django.utils.encoding.python_2_unicode_compatible()` alias was removed in Django 3.0.