### PR TITLE
Fix infinite redirect when logged in

### DIFF
--- a/django_comments/views/moderation.py
+++ b/django_comments/views/moderation.py
@@ -35,7 +35,8 @@ def flag(request, comment_id, next=None):
 
 
 @csrf_protect
-@permission_required("django_comments.can_moderate")
+@login_required
+@permission_required("django_comments.can_moderate", raise_exception=True)
 def delete(request, comment_id, next=None):
     """
     Deletes a comment. Confirmation on GET, action on POST. Requires the "can
@@ -63,7 +64,8 @@ def delete(request, comment_id, next=None):
 
 
 @csrf_protect
-@permission_required("django_comments.can_moderate")
+@login_required
+@permission_required("django_comments.can_moderate", raise_exception=True)
 def approve(request, comment_id, next=None):
     """
     Approve a comment (that is, mark it as public and non-removed). Confirmation

--- a/tests/testapp/tests/test_moderation_views.py
+++ b/tests/testapp/tests/test_moderation_views.py
@@ -111,11 +111,17 @@ class DeleteViewTests(CommentTestCase):
         """The delete view should only be accessible to 'moderators'"""
         comments = self.createSomeComments()
         pk = comments[0].pk
-        self.client.login(username="normaluser", password="normaluser")
+
+        # Test that we redirect to login page if not logged in.
         response = self.client.get("/delete/%d/" % pk)
         self.assertRedirects(response,
             "/accounts/login/?next=/delete/%d/" % pk,
             fetch_redirect_response=False)
+
+        # Test that we return forbidden if you're logged in but don't have access.
+        self.client.login(username="normaluser", password="normaluser")
+        response = self.client.get("/delete/%d/" % pk)
+        self.assertEqual(response.status_code, 403)
 
         makeModerator("normaluser")
         response = self.client.get("/delete/%d/" % pk)
@@ -185,7 +191,8 @@ class ApproveViewTests(CommentTestCase):
         """The approve view should only be accessible to 'moderators'"""
         comments = self.createSomeComments()
         pk = comments[0].pk
-        self.client.login(username="normaluser", password="normaluser")
+
+        # Test that we redirect to login page if not logged in.
         response = self.client.get("/approve/%d/" % pk)
         self.assertRedirects(
             response,
@@ -193,6 +200,12 @@ class ApproveViewTests(CommentTestCase):
             fetch_redirect_response=False
         )
 
+        # Test that we return forbidden if you're logged in but don't have access.
+        self.client.login(username="normaluser", password="normaluser")
+        response = self.client.get("/approve/%d/" % pk)
+        self.assertEqual(response.status_code, 403)
+
+        # Verify that moderators can view this view.
         makeModerator("normaluser")
         response = self.client.get("/approve/%d/" % pk)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
By default the `permission_required` decorator redirects to the login url
when you don't have sufficient permissions. The result of this is if
a user navigates to a page they don't have permission to view they end
up in an infinite redirect loop between the forbidden page and the login page.

This change will allow logged out users a chance to login but return
forbidden when you don't have sufficient permissions.