### PR TITLE
Patch to better handle bad comment content types

### DIFF
--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -52,7 +52,7 @@ def post_comment(request, next=None, using=None):
     try:
         model = apps.get_model(*ctype.split(".", 1))
         target = model._default_manager.using(using).get(pk=object_pk)
-    except TypeError:
+    except (LookupError, TypeError):
         return CommentPostBadRequest(
             "Invalid content_type value: %r" % escape(ctype))
     except AttributeError:

--- a/tests/testapp/tests/test_comment_views.py
+++ b/tests/testapp/tests/test_comment_views.py
@@ -32,6 +32,20 @@ class CommentViewTests(CommentTestCase):
         response = self.client.post("/post/", data)
         self.assertEqual(response.status_code, 400)
 
+    def testPostCommentBadCtypeInvalidModelName(self):
+        a = Article.objects.get(pk=1)
+        data = self.getValidData(a)
+        data["content_type"] = str(Article._meta) + "_91232"
+        response = self.client.post("/post/", data)
+        self.assertEqual(response.status_code, 400)
+
+    def testPostCommentBadCtypeInjectionAttempt(self):
+        a = Article.objects.get(pk=1)
+        data = self.getValidData(a)
+        data["content_type"] = str(Article._meta) + "'\"()&%<acx><ScRiPt >prompt(998230)</ScRiPt>"
+        response = self.client.post("/post/", data)
+        self.assertEqual(response.status_code, 400)
+
     def testPostCommentMissingObjectPK(self):
         a = Article.objects.get(pk=1)
         data = self.getValidData(a)


### PR DESCRIPTION
Fixed an issue with handling bad comment content types seen in the wild.

(The old behaviour raised a LookupError, and caused a 500 status code instead of the intended 400.)