### PR TITLE
add interchangable model keys support

### DIFF
--- a/django_comments/forms.py
+++ b/django_comments/forms.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from django.utils.translation import pgettext_lazy, ngettext, gettext, gettext_lazy as _
 
 from . import get_model
+from .utils import get_key_value
 
 COMMENT_MAX_LENGTH = getattr(settings, 'COMMENT_MAX_LENGTH', 3000)
 DEFAULT_COMMENTS_TIMEOUT = getattr(settings, 'COMMENTS_TIMEOUT', (2 * 60 * 60))  # 2h
@@ -65,7 +66,7 @@ class CommentSecurityForm(forms.Form):
         timestamp = int(time.time())
         security_dict = {
             'content_type': str(self.target_object._meta),
-            'object_pk': str(self.target_object._get_pk_val()),
+            'object_pk': get_key_value(self.target_object),
             'timestamp': str(timestamp),
             'security_hash': self.initial_security_hash(timestamp),
         }
@@ -79,7 +80,7 @@ class CommentSecurityForm(forms.Form):
 
         initial_security_dict = {
             'content_type': str(self.target_object._meta),
-            'object_pk': str(self.target_object._get_pk_val()),
+            'object_pk': get_key_value(self.target_object),
             'timestamp': str(timestamp),
         }
         return self.generate_security_hash(**initial_security_dict)
@@ -139,7 +140,7 @@ class CommentDetailsForm(CommentSecurityForm):
         """
         return dict(
             content_type=ContentType.objects.get_for_model(self.target_object),
-            object_pk=force_str(self.target_object._get_pk_val()),
+            object_pk=get_key_value(self.target_object),
             user_name=self.cleaned_data["name"],
             user_email=self.cleaned_data["email"],
             user_url=self.cleaned_data["url"],

--- a/django_comments/utils.py
+++ b/django_comments/utils.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from django.utils.encoding import force_str
+
+
+def get_key(model):
+    """
+    Get key of the model.
+
+    By default returns 'pk', but if COMMENTS_ID_OVERRIDES is defined,
+    returns the key defined by user.
+    """
+    COMMENTS_ID_OVERRIDES = getattr(settings, 'COMMENTS_ID_OVERRIDES', {})
+    class_identifier = f"{model._meta.app_label}.{model.__name__}"
+    if class_identifier in COMMENTS_ID_OVERRIDES:
+        return COMMENTS_ID_OVERRIDES[class_identifier]
+    else:
+        return 'pk'
+
+
+def get_key_value(target_object):
+    """
+    Get key of the model.
+
+    By default returns 'pk', but if COMMENTS_ID_OVERRIDES is defined,
+    returns the key defined by user.
+    """
+    key = get_key(target_object.__class__)
+    if key == 'pk':
+        return force_str(target_object._get_pk_val())
+    else:
+        return force_str(getattr(target_object, key))

--- a/django_comments/views/comments.py
+++ b/django_comments/views/comments.py
@@ -12,6 +12,7 @@ from django.views.decorators.http import require_POST
 import django_comments
 from django_comments import signals
 from django_comments.views.utils import next_redirect, confirmation_view
+from django_comments.utils import get_key
 
 
 class CommentPostBadRequest(http.HttpResponseBadRequest):
@@ -51,7 +52,7 @@ def post_comment(request, next=None, using=None):
         return CommentPostBadRequest("Missing content_type or object_pk field.")
     try:
         model = apps.get_model(*ctype.split(".", 1))
-        target = model._default_manager.using(using).get(pk=object_pk)
+        target = model._default_manager.using(using).get(**{get_key(model): object_pk})
     except (LookupError, TypeError):
         return CommentPostBadRequest(
             "Invalid content_type value: %r" % escape(ctype))

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -39,3 +39,20 @@ COMMENT_TIMEOUT
 
 The maximum comment form timeout in seconds. The default value is
 ``2 * 60 * 60`` (2 hours).
+
+
+COMMENTS_ID_OVERRIDES
+----------------------
+
+.. setting:: COMMENTS_ID_OVERRIDES
+
+A dictionary of ``{"app_label": "id_field"}`` pairs that override the
+PK used for referencing comment objects.
+
+If you want to disguise the plain IDs of your referenced model used by the comment form, you can
+use uuid field as an ID for the model. You don't have to change the model to use different PK.
+For example::
+
+    COMMENTS_ID_OVERRIDES = {
+        "myapp.MyModel": "uuid",
+    }

--- a/tests/testapp/fixtures/comment_tests.json
+++ b/tests/testapp/fixtures/comment_tests.json
@@ -27,6 +27,7 @@
     "pk" : 1,
     "fields" : {
         "author" : 1,
+        "uuid" : "336384ea-b04f-4a3a-a06a-1f25a8048f8f",
         "headline" : "Man Bites Dog"
     }
   },
@@ -35,6 +36,7 @@
     "pk" : 2,
     "fields" : {
         "author" : 2,
+        "uuid" : "d77c5d7d-1b0d-467b-814b-96697bd9a686",
         "headline" : "Dog Bites Man"
     }
   },

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -15,6 +15,7 @@ class Author(models.Model):
 
 
 class Article(models.Model):
+    uuid = models.UUIDField(editable=False, null=True)
     author = models.ForeignKey(Author, on_delete=models.CASCADE)
     headline = models.CharField(max_length=100)
 

--- a/tests/testapp/tests/test_comment_views.py
+++ b/tests/testapp/tests/test_comment_views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.test.utils import override_settings
 
 from django_comments import signals
 from django_comments.abstracts import COMMENT_MAX_LENGTH
@@ -332,6 +333,28 @@ class CommentViewTests(CommentTestCase):
         broken_location = location + "\ufffd"
         response = self.client.get(broken_location)
         self.assertEqual(response.status_code, 200)
+
+    @override_settings(
+        COMMENTS_ID_OVERRIDES={
+            "testapp.Article": "uuid",
+        }
+    )
+    def testCommentPostWithUUID(self):
+        """
+        Tests that attempting to retrieve the location specified in the
+        post redirect, after adding some invalid data to the expected
+        querystring it ends with, doesn't cause a server error.
+        """
+        a = Article.objects.get(pk=1)
+        data = self.getValidData(a)
+        data["comment"] = "This is another comment"
+        self.assertEqual(data["object_pk"], "336384ea-b04f-4a3a-a06a-1f25a8048f8f")
+        response = self.client.post("/post/", data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Comment.objects.count(), 1)
+        self.assertEqual(
+            Comment.objects.first().object_pk, "336384ea-b04f-4a3a-a06a-1f25a8048f8f"
+        )
 
     def testCommentNextWithQueryStringAndAnchor(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,4 @@ deps=
     django-40: Django>=4.0a1,<4.1
     django-41: Django>=4.1a1,<4.2
     django-main: https://github.com/django/django/archive/main.tar.gz
+    freezegun


### PR DESCRIPTION
Add possibility to change target object key field by `COMMENTS_ID_OVERRIDES` settings, e.g.:
```python
COMMENTS_ID_OVERRIDES = {
    'assets.Asset': 'asset_uuid',
}
```

I have model with `id` field as PK and want to use another non-PK `uuid` field to use for comments (to avoid showing object IDs to users).

This is conceptual draft of the functionality that enables that through one simple mapping in settings.

Please review if this concept makes sens. If yes, I will do following things:
- [x] Check, that the new settings is used everywhere.
- [x] Add documentation
- [x] Add tests